### PR TITLE
SDK-167: Add Testing Support

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,4 @@
+github "erikdoe/ocmock"
+github "Quick/Quick"
+github "Quick/Nimble"
+github "SDWebImage/SDWebImage"

--- a/mParticle-CleverTap.xcodeproj/project.pbxproj
+++ b/mParticle-CleverTap.xcodeproj/project.pbxproj
@@ -3,32 +3,44 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D02BDC6521A3B03100209F59 /* CleverTapSDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D076C317218E3DEE00185E1A /* CleverTapSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D02BDC6621A3B03500209F59 /* mParticle_Apple_SDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D071FD9C21A3AB600060F803 /* CleverTapSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D076C317218E3DEE00185E1A /* CleverTapSDK.framework */; };
-		D071FD9D21A3AB630060F803 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */; };
+		D071FD9C21A3AB600060F803 /* CleverTapSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D076C317218E3DEE00185E1A /* CleverTapSDK.framework */; platformFilter = ios; };
+		D071FD9D21A3AB630060F803 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */; platformFilter = ios; };
 		D076C318218E3DEE00185E1A /* CleverTapSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D076C317218E3DEE00185E1A /* CleverTapSDK.framework */; };
 		D076C320218E413700185E1A /* mParticle_CleverTapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D076C31F218E413700185E1A /* mParticle_CleverTapTests.m */; };
-		D076C322218E413700185E1A /* mParticle_CleverTap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A5B1DC1478A00A7B188 /* mParticle_CleverTap.framework */; };
+		D076C322218E413700185E1A /* mParticle_CleverTap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A5B1DC1478A00A7B188 /* mParticle_CleverTap.framework */; platformFilter = ios; };
 		DBB01A601DC1478A00A7B188 /* mParticle_CleverTap.h in Headers */ = {isa = PBXBuildFile; fileRef = DBB01A5E1DC1478A00A7B188 /* mParticle_CleverTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBB01A681DC1480700A7B188 /* MPKitCleverTap.h in Headers */ = {isa = PBXBuildFile; fileRef = DBB01A661DC1480700A7B188 /* MPKitCleverTap.h */; };
 		DBB01A691DC1480700A7B188 /* MPKitCleverTap.m in Sources */ = {isa = PBXBuildFile; fileRef = DBB01A671DC1480700A7B188 /* MPKitCleverTap.m */; };
 		DBB01A6B1DC1491D00A7B188 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */; };
+		F94BD3C62492E0E400FC144C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94BD3C22492E0E400FC144C /* Nimble.framework */; platformFilter = ios; };
+		F94BD3C72492E0E400FC144C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94BD3C32492E0E400FC144C /* Quick.framework */; platformFilter = ios; };
+		F94BD3C82492E0E400FC144C /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94BD3C42492E0E400FC144C /* SDWebImage.framework */; platformFilter = ios; };
+		F94BD3C92492E0E400FC144C /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94BD3C52492E0E400FC144C /* OCMock.framework */; platformFilter = ios; };
+		F94BD3CA2492E11E00FC144C /* CleverTapSDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D076C317218E3DEE00185E1A /* CleverTapSDK.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F94BD3CB2492E11E00FC144C /* mParticle_Apple_SDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F94BD3CC2492E11E00FC144C /* OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F94BD3C52492E0E400FC144C /* OCMock.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F94BD3CD2492E11E00FC144C /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F94BD3C22492E0E400FC144C /* Nimble.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F94BD3CE2492E11E00FC144C /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F94BD3C32492E0E400FC144C /* Quick.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F94BD3CF2492E11E00FC144C /* SDWebImage.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F94BD3C42492E0E400FC144C /* SDWebImage.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		D02BDC6421A3B02600209F59 /* CopyFiles */ = {
+		F9F952872492DFB100BF8325 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D02BDC6621A3B03500209F59 /* mParticle_Apple_SDK.framework in CopyFiles */,
-				D02BDC6521A3B03100209F59 /* CleverTapSDK.framework in CopyFiles */,
+				F94BD3CA2492E11E00FC144C /* CleverTapSDK.framework in CopyFiles */,
+				F94BD3CB2492E11E00FC144C /* mParticle_Apple_SDK.framework in CopyFiles */,
+				F94BD3CC2492E11E00FC144C /* OCMock.framework in CopyFiles */,
+				F94BD3CD2492E11E00FC144C /* Nimble.framework in CopyFiles */,
+				F94BD3CE2492E11E00FC144C /* Quick.framework in CopyFiles */,
+				F94BD3CF2492E11E00FC144C /* SDWebImage.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -46,6 +58,11 @@
 		DBB01A661DC1480700A7B188 /* MPKitCleverTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitCleverTap.h; sourceTree = "<group>"; };
 		DBB01A671DC1480700A7B188 /* MPKitCleverTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPKitCleverTap.m; sourceTree = "<group>"; };
 		DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
+		F92C71612492E1BF00CA336E /* mParticle-CleverTap.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "mParticle-CleverTap.xctestplan"; sourceTree = "<group>"; };
+		F94BD3C22492E0E400FC144C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
+		F94BD3C32492E0E400FC144C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
+		F94BD3C42492E0E400FC144C /* SDWebImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDWebImage.framework; path = Carthage/Build/iOS/SDWebImage.framework; sourceTree = "<group>"; };
+		F94BD3C52492E0E400FC144C /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Carthage/Build/iOS/OCMock.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,9 +70,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F94BD3C62492E0E400FC144C /* Nimble.framework in Frameworks */,
+				F94BD3C72492E0E400FC144C /* Quick.framework in Frameworks */,
+				F94BD3C82492E0E400FC144C /* SDWebImage.framework in Frameworks */,
+				F94BD3C92492E0E400FC144C /* OCMock.framework in Frameworks */,
 				D071FD9C21A3AB600060F803 /* CleverTapSDK.framework in Frameworks */,
-				D076C322218E413700185E1A /* mParticle_CleverTap.framework in Frameworks */,
 				D071FD9D21A3AB630060F803 /* mParticle_Apple_SDK.framework in Frameworks */,
+				D076C322218E413700185E1A /* mParticle_CleverTap.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -75,6 +96,7 @@
 			isa = PBXGroup;
 			children = (
 				D076C31F218E413700185E1A /* mParticle_CleverTapTests.m */,
+				F92C71612492E1BF00CA336E /* mParticle-CleverTap.xctestplan */,
 				D076C321218E413700185E1A /* Info.plist */,
 			);
 			path = mParticle_CleverTapTests;
@@ -115,6 +137,10 @@
 		FF13226121878D9C002AA653 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F94BD3C52492E0E400FC144C /* OCMock.framework */,
+				F94BD3C22492E0E400FC144C /* Nimble.framework */,
+				F94BD3C32492E0E400FC144C /* Quick.framework */,
+				F94BD3C42492E0E400FC144C /* SDWebImage.framework */,
 				D071FD9A21A3A9700060F803 /* XCTest.framework */,
 			);
 			name = Frameworks;
@@ -142,7 +168,7 @@
 				D076C319218E413700185E1A /* Sources */,
 				D076C31A218E413700185E1A /* Frameworks */,
 				D076C31B218E413700185E1A /* Resources */,
-				D02BDC6421A3B02600209F59 /* CopyFiles */,
+				F9F952872492DFB100BF8325 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -193,7 +219,7 @@
 				};
 			};
 			buildConfigurationList = DBB01A551DC1478A00A7B188 /* Build configuration list for PBXProject "mParticle-CleverTap" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -264,8 +290,12 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = mParticle_CleverTapTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.clevertap.mParticle-CleverTapTests";
@@ -291,8 +321,12 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = mParticle_CleverTapTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.clevertap.mParticle-CleverTapTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -433,7 +467,11 @@
 				INFOPLIST_FILE = "mParticle-CleverTap/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-CleverTap";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -456,7 +494,11 @@
 				INFOPLIST_FILE = "mParticle-CleverTap/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-CleverTap";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/mParticle-CleverTap.xcodeproj/project.pbxproj
+++ b/mParticle-CleverTap.xcodeproj/project.pbxproj
@@ -7,25 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D071FD9C21A3AB600060F803 /* CleverTapSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D076C317218E3DEE00185E1A /* CleverTapSDK.framework */; platformFilter = ios; };
-		D071FD9D21A3AB630060F803 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */; platformFilter = ios; };
 		D076C318218E3DEE00185E1A /* CleverTapSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D076C317218E3DEE00185E1A /* CleverTapSDK.framework */; };
 		D076C320218E413700185E1A /* mParticle_CleverTapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D076C31F218E413700185E1A /* mParticle_CleverTapTests.m */; };
-		D076C322218E413700185E1A /* mParticle_CleverTap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A5B1DC1478A00A7B188 /* mParticle_CleverTap.framework */; platformFilter = ios; };
 		DBB01A601DC1478A00A7B188 /* mParticle_CleverTap.h in Headers */ = {isa = PBXBuildFile; fileRef = DBB01A5E1DC1478A00A7B188 /* mParticle_CleverTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBB01A681DC1480700A7B188 /* MPKitCleverTap.h in Headers */ = {isa = PBXBuildFile; fileRef = DBB01A661DC1480700A7B188 /* MPKitCleverTap.h */; };
 		DBB01A691DC1480700A7B188 /* MPKitCleverTap.m in Sources */ = {isa = PBXBuildFile; fileRef = DBB01A671DC1480700A7B188 /* MPKitCleverTap.m */; };
 		DBB01A6B1DC1491D00A7B188 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */; };
-		F94BD3C62492E0E400FC144C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94BD3C22492E0E400FC144C /* Nimble.framework */; platformFilter = ios; };
-		F94BD3C72492E0E400FC144C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94BD3C32492E0E400FC144C /* Quick.framework */; platformFilter = ios; };
-		F94BD3C82492E0E400FC144C /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94BD3C42492E0E400FC144C /* SDWebImage.framework */; platformFilter = ios; };
-		F94BD3C92492E0E400FC144C /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94BD3C52492E0E400FC144C /* OCMock.framework */; platformFilter = ios; };
 		F94BD3CA2492E11E00FC144C /* CleverTapSDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D076C317218E3DEE00185E1A /* CleverTapSDK.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F94BD3CB2492E11E00FC144C /* mParticle_Apple_SDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DBB01A6A1DC1491D00A7B188 /* mParticle_Apple_SDK.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F94BD3CC2492E11E00FC144C /* OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F94BD3C52492E0E400FC144C /* OCMock.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F94BD3CD2492E11E00FC144C /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F94BD3C22492E0E400FC144C /* Nimble.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F94BD3CE2492E11E00FC144C /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F94BD3C32492E0E400FC144C /* Quick.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F94BD3CF2492E11E00FC144C /* SDWebImage.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F94BD3C42492E0E400FC144C /* SDWebImage.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F9D946AA24A08D25009DAB4B /* mParticle_CleverTap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB01A5B1DC1478A00A7B188 /* mParticle_CleverTap.framework */; platformFilter = ios; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -70,13 +64,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F94BD3C62492E0E400FC144C /* Nimble.framework in Frameworks */,
-				F94BD3C72492E0E400FC144C /* Quick.framework in Frameworks */,
-				F94BD3C82492E0E400FC144C /* SDWebImage.framework in Frameworks */,
-				F94BD3C92492E0E400FC144C /* OCMock.framework in Frameworks */,
-				D071FD9C21A3AB600060F803 /* CleverTapSDK.framework in Frameworks */,
-				D071FD9D21A3AB630060F803 /* mParticle_Apple_SDK.framework in Frameworks */,
-				D076C322218E413700185E1A /* mParticle_CleverTap.framework in Frameworks */,
+				F9D946AA24A08D25009DAB4B /* mParticle_CleverTap.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mParticle-CleverTap.xcodeproj/xcshareddata/xcschemes/mParticle_CleverTapTests.xcscheme
+++ b/mParticle-CleverTap.xcodeproj/xcshareddata/xcschemes/mParticle_CleverTapTests.xcscheme
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1150"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DBB01A5A1DC1478A00A7B188"
-               BuildableName = "mParticle_CleverTap.framework"
-               BlueprintName = "mParticle-CleverTap"
-               ReferencedContainer = "container:mParticle-CleverTap.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -57,15 +41,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DBB01A5A1DC1478A00A7B188"
-            BuildableName = "mParticle_CleverTap.framework"
-            BlueprintName = "mParticle-CleverTap"
-            ReferencedContainer = "container:mParticle-CleverTap.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,15 +48,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DBB01A5A1DC1478A00A7B188"
-            BuildableName = "mParticle_CleverTap.framework"
-            BlueprintName = "mParticle-CleverTap"
-            ReferencedContainer = "container:mParticle-CleverTap.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/mParticle_CleverTapTests/mParticle-CleverTap.xctestplan
+++ b/mParticle_CleverTapTests/mParticle-CleverTap.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "14CF70B9-3D21-463E-8650-9DA19434AE3F",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:mParticle-CleverTap.xcodeproj",
+      "identifier" : "DBB01A5A1DC1478A00A7B188",
+      "name" : "mParticle-CleverTap"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:mParticle-CleverTap.xcodeproj",
+        "identifier" : "D076C31C218E413700185E1A",
+        "name" : "mParticle_CleverTapTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/mParticle_CleverTapTests/mParticle_CleverTapTests.m
+++ b/mParticle_CleverTapTests/mParticle_CleverTapTests.m
@@ -1,28 +1,314 @@
-#import <XCTest/XCTest.h>
+
+@import Quick;
+@import Nimble;
+@import OCMock;
+@import CleverTapSDK;
+@import mParticle_Apple_SDK;
 #import "MPKitCleverTap.h"
 
-@interface mParticle_CleverTapTests : XCTestCase
 
-@end
+QuickSpecBegin(MPKitCleverTapSpec)
 
-@implementation mParticle_CleverTapTests
+describe(@"a mParticle CleverTap integration", ^{
+    
+    context(@"conforming to MPKitProtocol", ^{
+        
+        __block MPKitCleverTap *clevertapKit;
+        beforeEach(^{
+            clevertapKit = [MPKitCleverTap new];
+        });
+        
+        afterEach(^{
+            clevertapKit = nil;
+        });
+        
+        it(@"is not started with empty Configuration", ^{
+            [clevertapKit didFinishLaunchingWithConfiguration:@{}];
+            expect(clevertapKit.started).toNot(beTrue());
+        });
+        
+        it(@"verifies properties are set correctly", ^{
+            
+            NSDictionary *config = @{ @"AccountID": @"12345", @"AccountToken": @"54321" };
+            
+            [clevertapKit didFinishLaunchingWithConfiguration:config];
+            
+            expect(clevertapKit.started).to(beTrue());
+            expect(clevertapKit.launchOptions).to(beNil());
+            expect(clevertapKit.configuration).to(equal(config));
+            expect(clevertapKit.providerKitInstance).to(beAKindOf([CleverTap class]));
+        });
+        
+        it(@"handles push notifications clicks", ^{
+            
+            id mockCleverTap = OCMStrictClassMock([CleverTap class]);
+            
+            id mockNotificationCenter = OCMClassMock([UNUserNotificationCenter class]);
+            id mockNotificationResponse = OCMClassMock([UNNotificationResponse class]);
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
+            [[mockCleverTap expect] handlePushNotification:[OCMArg any] openDeepLinksInForeground:[OCMArg any]];
+            
+            [clevertapKit userNotificationCenter:mockNotificationCenter didReceiveNotificationResponse:mockNotificationResponse];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"handles push notification actions", ^{
+            
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap handleNotificationWithData:[OCMArg any]]);
+            
+            [clevertapKit handleActionWithIdentifier:[OCMArg any] forRemoteNotification:[OCMArg any]];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"handles push notification actions with response info", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap handleNotificationWithData:[OCMArg any]]);
+            
+            [clevertapKit handleActionWithIdentifier:[OCMArg any] forRemoteNotification:[OCMArg any] withResponseInfo:[OCMArg any]];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies user notifications are received", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap handleNotificationWithData:[OCMArg any]]);
+            
+            [clevertapKit receivedUserNotification:[OCMArg any]];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies push token is set", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap setPushToken:[OCMArg any]]);
+            
+            [clevertapKit setDeviceToken:[OCMArg any]];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies open URL with options is handled", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap handleOpenURL:[OCMArg any] sourceApplication:[OCMArg any]]);
+            
+            [clevertapKit openURL:[OCMArg any] options:[OCMArg any]];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies open URL from source application is handled", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap handleOpenURL:[OCMArg any] sourceApplication:[OCMArg any]]);
+            
+            [clevertapKit openURL:[OCMArg any] sourceApplication:[OCMArg any] annotation:[OCMArg any]];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies location is set", ^{
+            
+            CLLocation *mockLocation = OCMClassMock([CLLocation class]);
+            MPKitExecStatus *status = [clevertapKit setLocation:mockLocation];
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
+            expect(@(status.returnCode)).to(equal(MPKitReturnCodeSuccess));
+        });
+        
+        it(@"verifies user attributes are set via profile push", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap profilePush:@{ @"key": @"value" }]);
+            
+            [clevertapKit setUserAttribute:@"key" value:@"value"];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies user attributes are removed", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap profileRemoveValueForKey:[OCMArg any]]);
+            
+            [clevertapKit removeUserAttribute:[OCMArg any]];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies multiple user attributes are set", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap profileAddMultiValues:[OCMArg any] forKey:[OCMArg any]]);
+            
+            [clevertapKit setUserAttribute:[OCMArg any] values:[OCMArg any]];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies on user login is NOT invoked for incorrect payload onLoginComplete invocation", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMReject([mockCleverTap onUserLogin:[OCMArg any]]);
+            OCMReject([mockCleverTap profilePush:[OCMArg any]]);
+            
+            id mockUser = OCMClassMock([FilteredMParticleUser class]);
+            id mockRequest = OCMClassMock([FilteredMPIdentityApiRequest class]);
+            [clevertapKit onLoginComplete:mockUser request:mockRequest];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies on user login is NOT invoked for incorrect payload onIdentifyComplete invocation" , ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMReject([mockCleverTap onUserLogin:[OCMArg any]]);
+            OCMReject([mockCleverTap profilePush:[OCMArg any]]);
+            
+            id mockUser = OCMClassMock([FilteredMParticleUser class]);
+            id mockRequest = OCMClassMock([FilteredMPIdentityApiRequest class]);
+            [clevertapKit onIdentifyComplete:mockUser request:mockRequest];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies on user login is NOT invoked for incorrect payload onIdentifyComplete invocation" , ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMReject([mockCleverTap onUserLogin:[OCMArg any]]);
+            OCMReject([mockCleverTap profilePush:[OCMArg any]]);
+            
+            id mockUser = OCMClassMock([FilteredMParticleUser class]);
+            id mockRequest = OCMClassMock([FilteredMPIdentityApiRequest class]);
+            [clevertapKit onModifyComplete:mockUser request:mockRequest];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"rejects events with incorrect values", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMReject([mockCleverTap recordEvent:[OCMArg any] withProps:[OCMArg any]]);
+            OCMReject([mockCleverTap recordChargedEventWithDetails:[OCMArg any] andItems:[OCMArg any]]);
+            
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wdeprecated"
+            
+            id mockEvent = OCMClassMock([MPCommerceEvent class]);
+            [clevertapKit logCommerceEvent:mockEvent];
+            
+            #pragma clang diagnostic pop
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies charged event is fired on Purchase Action Events", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap recordChargedEventWithDetails:[OCMArg any] andItems:[OCMArg any]]);
+            
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wdeprecated"
+            
+            MPCommerceEvent *niceEvent = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionPurchase];
+            [clevertapKit logCommerceEvent:niceEvent];
+            
+            #pragma clang diagnostic pop
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies events are logged", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap recordEvent:[OCMArg any] withProps:[OCMArg any]]);
+            
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wdeprecated"
+            
+            id mockEvent = OCMClassMock([MPEvent class]);
+            [clevertapKit logEvent:mockEvent];
+            
+            #pragma clang diagnostic pop
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"rejects recordScreenView for incorrect payload", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMReject([mockCleverTap recordScreenView:[OCMArg any]]);
+            
+            id mockEvent = OCMClassMock([MPEvent class]);
+            [clevertapKit logScreen:mockEvent];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies recordScreenView is invoked on logScreen invocation", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([mockCleverTap recordScreenView:[OCMArg any]]);
+            
+            MPEvent *niceEvent = [[MPEvent alloc] initWithName:@"ScreenName" type:MPEventTypeUserContent];
+            [clevertapKit logScreen:niceEvent];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+        
+        it(@"verifies user opt out is set", ^{
+            [CleverTap setCredentialsWithAccountID:@"12345" andToken:@"54321"];
+            
+            id mockCleverTap = OCMPartialMock([CleverTap sharedInstance]);
+            
+            OCMExpect([(CleverTap *)mockCleverTap setOptOut:YES]);
+            
+            [clevertapKit setOptOut:YES];
+            
+            OCMVerifyAll(mockCleverTap);
+        });
+    });
+});
 
-- (void)testModuleID {
-    XCTAssertEqualObjects([MPKitCleverTap kitCode], @135);
-}
+QuickSpecEnd
 
-- (void)testStarted {
-    MPKitCleverTap *clevertapKit = [[MPKitCleverTap alloc] init];
-    [clevertapKit didFinishLaunchingWithConfiguration:@{@"AccountID":@"12345", @"AccountToken":@"54321"}];
-    XCTAssertTrue(clevertapKit.started);
-}
-
-@end


### PR DESCRIPTION
- Added tests dependencies via [Cartfile.private](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfileprivate) 
- Dependent projects **cannot** see anything listed in the private Cartfile so will be unaffected
- No impact in usage for Cocoapods clients
- Tests have been added under the existing folder "mParticle_CleverTapTests"
- Project structure remains similar, only Cartfile.private has been added
- The Behaviour Tests make the wrapper SDK resilient to future changes in both mParticle & CleverTap SDKs
- Test Code Coverage is now at above 82% 😍 🙌

<img width="1403" alt="Screenshot 2020-06-12 at 2 58 17 AM" src="https://user-images.githubusercontent.com/8512357/84444428-62f02f80-ac5f-11ea-8d18-9ba3d784fd11.png">
